### PR TITLE
Add Docker setup and helper scripts

### DIFF
--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM maven:3.9.4-eclipse-temurin-21 AS build
+WORKDIR /workspace
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q package -DskipTests
+
+# Runtime stage
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /workspace/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/backend/worker/Dockerfile
+++ b/backend/worker/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM maven:3.9.4-eclipse-temurin-21 AS build
+WORKDIR /workspace
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q package -DskipTests
+
+# Runtime stage with CUDA
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+WORKDIR /app
+RUN apt-get update && apt-get install -y openjdk-21-jre-headless && rm -rf /var/lib/apt/lists/*
+COPY --from=build /workspace/target/*.jar app.jar
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+docker compose up --build "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+version: '3.9'
+services:
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:80"
+    depends_on:
+      - api
+  api:
+    build: ./backend/api
+    ports:
+      - "8080:8080"
+    environment:
+      - REDIS_HOST=redis
+      - S3_ENDPOINT=http://minio:9000
+      - AWS_ACCESS_KEY_ID=minio
+      - AWS_SECRET_ACCESS_KEY=minio123
+    depends_on:
+      - redis
+      - minio
+  worker:
+    build: ./backend/worker
+    environment:
+      - REDIS_HOST=redis
+      - S3_ENDPOINT=http://minio:9000
+      - AWS_ACCESS_KEY_ID=minio
+      - AWS_SECRET_ACCESS_KEY=minio123
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    depends_on:
+      - redis
+      - minio
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address :9001
+    environment:
+      - MINIO_ROOT_USER=minio
+      - MINIO_ROOT_PASSWORD=minio123
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+volumes:
+  minio-data:

--- a/e2e.sh
+++ b/e2e.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+docker compose up -d
+trap "docker compose down" EXIT
+sleep 5
+curl -fsS -X POST http://localhost:8080/v1/auth/token \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"test"}'
+echo

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:20 AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/render.sh
+++ b/render.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+docker compose run --rm worker "$@"


### PR DESCRIPTION
## Summary
- containerize frontend build with Vite and nginx
- add Dockerfiles for API and GPU-enabled worker
- introduce docker-compose stack with helper scripts for dev, render, and e2e

## Testing
- `CI=true npm test`
- `mvn -q test` (backend/api) *(fails: network is unreachable)*
- `mvn -q test` (backend/worker) *(fails: network is unreachable)*
- `./e2e.sh` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68be7b975a10832e9f7cfc40897a216e