### PR TITLE
docs: expand project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,81 @@
 # Test Video Editing App
 
-Anime Video editing program that changes the style of the anime style to a new one.
+Anime video editing stack that stylizes frames with AnimeGANv2 and related models.
 
-## Pre-trained models
+## Overview
 
-Run `python scripts/download_models.py` to fetch a small AnimeGANv2 ONNX model for local experiments.
+This repository contains a full-stack sample project that:
 
-The model is saved under `models/` by default. Set the `MODEL_DIR` environment variable to change the download location.
+- serves a Vite/TypeScript **frontend** for job submission,
+- exposes a Spring Boot **API** for authentication and job management,
+- runs a Spring Boot **worker** that processes queued video jobs, and
+- relies on **Redis** for messaging and **MinIO** for object storage.
 
-## Example video
+## Architecture
 
-Generate a short synthetic 1080p clip by running `python scripts/create_sample_video.py`.
-The script requires the `numpy` and `imageio[ffmpeg]` Python packages.
-The video is saved as `examples/sample_1080p.mp4` by default; set `EXAMPLE_VIDEO`
-to change the output path or to point to a different input file.
+```
+frontend → API → Redis queue → worker → MinIO
+```
+
+The frontend obtains a JWT token from the API, uploads video files to MinIO using
+presigned URLs, and creates jobs. Jobs are enqueued in Redis and consumed by the
+worker, which applies style transfer, optical-flow warping, and optional upscaling
+before writing results back to MinIO.
 
 ## Environment variables
 
-| Variable       | Description                                 | Default                     |
-| -------------- | ------------------------------------------- | --------------------------- |
-| `MODEL_DIR`    | Directory where ONNX models are stored      | `models/`                   |
-| `EXAMPLE_VIDEO`| Path to input video for local testing       | `examples/sample_1080p.mp4` |
+| Variable                | Description                                  | Default                |
+| ----------------------- | -------------------------------------------- | ---------------------- |
+| `MODEL_DIR`             | Directory where ONNX models are stored       | `models/`              |
+| `EXAMPLE_VIDEO`         | Path to input video for local testing        | `examples/sample_1080p.mp4` |
+| `REDIS_HOST`            | Redis hostname used by API and worker        | `redis`                |
+| `S3_ENDPOINT`           | MinIO/S3 endpoint                            | `http://minio:9000`    |
+| `AWS_ACCESS_KEY_ID`     | MinIO access key                             | `minio`                |
+| `AWS_SECRET_ACCESS_KEY` | MinIO secret key                             | `minio123`             |
+| `MINIO_ROOT_USER`       | MinIO root username                          | `minio`                |
+| `MINIO_ROOT_PASSWORD`   | MinIO root password                          | `minio123`             |
+
+## CLI commands
+
+| Command                                 | Purpose                                   |
+| --------------------------------------- | ----------------------------------------- |
+| `python scripts/download_models.py`     | Fetch small pre-trained ONNX models       |
+| `python scripts/create_sample_video.py` | Generate a synthetic 1080p MP4 clip       |
+| `./dev.sh`                              | Build and start the Docker stack          |
+| `./e2e.sh`                              | Start stack and request a JWT token       |
+| `./render.sh`                           | Run the worker container for one-off jobs |
+
+## Running the Docker stack
+
+```bash
+./dev.sh
+```
+
+The script runs `docker compose up --build` and launches the frontend on port
+`3000` and the API on `8080`.
+
+## Running tests
+
+- Frontend: `npm test` inside the `frontend/` folder.
+- Backend API: `mvn test` inside `backend/api` *(requires internet access for Maven dependencies)*.
+- Backend worker: `mvn test` inside `backend/worker` *(requires internet access)*.
+- End-to-end API check: `./e2e.sh`.
+
+## Sample render
+
+1. Download models: `python scripts/download_models.py`.
+2. Generate test clip: `python scripts/create_sample_video.py`.
+3. Start the stack: `./dev.sh`.
+4. Obtain a token: `curl -X POST http://localhost:8080/v1/auth/token -H 'Content-Type: application/json' -d '{"username":"test"}'`.
+5. Initialize an upload to get a presigned URL: `curl -H "Authorization: Bearer $TOKEN" -X POST http://localhost:8080/v1/uploads/init -d '{"filename":"sample_1080p.mp4"}'`.
+6. Upload the video to the returned URL, then create a job:
+   `curl -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -X POST http://localhost:8080/v1/jobs -d '{"objectKey":"sample_1080p.mp4","superResolution":false}'`.
+7. Monitor progress via `ws://localhost:8080/v1/jobs/{id}/ws`.
+
+## Security and GPU requirements
+
+- **Authentication**: All endpoints except `/v1/auth/token` require a valid JWT token. The signing secret in `SecurityConfig` should be replaced with a strong value in production.
+- **Credentials**: MinIO credentials in `docker-compose.yml` are for local use only; change them for deployments.
+- **GPU**: The worker checks for NVENC support and uses it when available. Running the stack with GPU acceleration requires an NVIDIA GPU, recent drivers, and the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/overview.html).
+
 


### PR DESCRIPTION
## Summary
- expand README with project overview and architecture
- document environment variables and CLI scripts
- add Docker stack, testing, sample render, security and GPU guidance

## Testing
- `npm test`
- `mvn -q test` (backend/api) *(fails: Could not resolve parent POM)*
- `mvn -q test` (backend/worker) *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_68be92c4bbe4832eb12894a09ab50ea6