### PR TITLE
Fix upside-down WebGL video texture

### DIFF
--- a/frontend/src/webgl.ts
+++ b/frontend/src/webgl.ts
@@ -48,6 +48,7 @@ export function applyShader(video: HTMLVideoElement, canvas: HTMLCanvasElement) 
   const tex = gl.createTexture();
   gl.bindTexture(gl.TEXTURE_2D, tex);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
   function render() {
     if (video.readyState >= 2) {
       gl.texImage2D(gl.TEXTURE_2D,0,gl.RGBA,gl.RGBA,gl.UNSIGNED_BYTE,video);


### PR DESCRIPTION
## Summary
- use `gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true)` when uploading frames so WebGL video renders right-side up

## Testing
- `npm --prefix frontend test -- --run`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_b_68beb85056e4832eb2989d1b5e7ef8d1