### PR TITLE
Add real-time WebGL stylization controls

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,6 +14,11 @@
       <video id="original" controls></video>
       <canvas id="styled"></canvas>
     </div>
+    <div class="shader-controls">
+      <label>Edge Weight <input type="range" id="edge" min="0" max="5" step="0.1" value="1" /></label>
+      <label>Posterize <input type="range" id="poster" min="1" max="20" step="1" value="8" /></label>
+      <label>Saturation <input type="range" id="saturation" min="0" max="2" step="0.1" value="1" /></label>
+    </div>
     <div class="controls">
       <label>Start <input type="number" id="start" value="0" /></label>
       <label>End <input type="number" id="end" value="0" /></label>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -2,6 +2,7 @@ import './style.css';
 import { STYLES, applyStyle } from './presets';
 import { convertToWebM } from './ffmpeg';
 import { hasWebGL, applyShader } from './webgl';
+import type { ShaderController } from './webgl';
 
 const uploadInput = document.getElementById('upload') as HTMLInputElement;
 const original = document.getElementById('original') as HTMLVideoElement;
@@ -11,6 +12,11 @@ const startInput = document.getElementById('start') as HTMLInputElement;
 const endInput = document.getElementById('end') as HTMLInputElement;
 const renderBtn = document.getElementById('render') as HTMLButtonElement;
 const progress = document.getElementById('progress') as HTMLProgressElement;
+const edgeInput = document.getElementById('edge') as HTMLInputElement;
+const posterInput = document.getElementById('poster') as HTMLInputElement;
+const saturationInput = document.getElementById('saturation') as HTMLInputElement;
+
+let shader: ShaderController | null = null;
 
 // Populate style options
 for (const p of STYLES) {
@@ -27,9 +33,24 @@ uploadInput.addEventListener('change', () => {
   original.onloadedmetadata = () => {
     endInput.value = Math.floor(original.duration).toString();
     if (hasWebGL()) {
-      applyShader(original, styled);
+      shader = applyShader(original, styled) || null;
+      shader?.setUniforms({
+        edgeWeight: parseFloat(edgeInput.value),
+        posterize: parseFloat(posterInput.value),
+        saturation: parseFloat(saturationInput.value)
+      });
     }
   };
+});
+
+edgeInput.addEventListener('input', () => {
+  shader?.setUniforms({ edgeWeight: parseFloat(edgeInput.value) });
+});
+posterInput.addEventListener('input', () => {
+  shader?.setUniforms({ posterize: parseFloat(posterInput.value) });
+});
+saturationInput.addEventListener('input', () => {
+  shader?.setUniforms({ saturation: parseFloat(saturationInput.value) });
 });
 
 async function renderFrame() {

--- a/frontend/src/webgl.ts
+++ b/frontend/src/webgl.ts
@@ -6,13 +6,25 @@ export function hasWebGL(): boolean {
   );
 }
 
-// Minimal shader that simply draws the video frame
-export function applyShader(video: HTMLVideoElement, canvas: HTMLCanvasElement) {
+export interface ShaderController {
+  setUniforms(values: {
+    edgeWeight?: number;
+    posterize?: number;
+    saturation?: number;
+  }): void;
+}
+
+// Draw the video frame with additional stylization controls
+export function applyShader(
+  video: HTMLVideoElement,
+  canvas: HTMLCanvasElement
+): ShaderController | void {
   const maybeGl = canvas.getContext('webgl') as WebGLRenderingContext | null;
   if (!maybeGl) return;
   const gl: WebGLRenderingContext = maybeGl;
   canvas.width = video.videoWidth;
   canvas.height = video.videoHeight;
+
   const program = gl.createProgram();
   if (!program) return;
   const vsrc = `
@@ -26,8 +38,36 @@ export function applyShader(video: HTMLVideoElement, canvas: HTMLCanvasElement) 
   const fsrc = `
     precision mediump float;
     uniform sampler2D t;
+    uniform vec2 pixel;
+    uniform float edgeWeight;
+    uniform float posterize;
+    uniform float saturation;
     varying vec2 v;
-    void main(){gl_FragColor = texture2D(t,v);}
+    void main(){
+      vec3 luma = vec3(0.299, 0.587, 0.114);
+      float tl = dot(texture2D(t, v + pixel * vec2(-1.0, -1.0)).rgb, luma);
+      float tm = dot(texture2D(t, v + pixel * vec2( 0.0, -1.0)).rgb, luma);
+      float tr = dot(texture2D(t, v + pixel * vec2( 1.0, -1.0)).rgb, luma);
+      float ml = dot(texture2D(t, v + pixel * vec2(-1.0,  0.0)).rgb, luma);
+      float mr = dot(texture2D(t, v + pixel * vec2( 1.0,  0.0)).rgb, luma);
+      float bl = dot(texture2D(t, v + pixel * vec2(-1.0,  1.0)).rgb, luma);
+      float bm = dot(texture2D(t, v + pixel * vec2( 0.0,  1.0)).rgb, luma);
+      float br = dot(texture2D(t, v + pixel * vec2( 1.0,  1.0)).rgb, luma);
+
+      float gx = -tl - 2.0 * ml - bl + tr + 2.0 * mr + br;
+      float gy = -tl - 2.0 * tm - tr + bl + 2.0 * bm + br;
+      float edge = length(vec2(gx, gy)) / 4.0;
+      edge = clamp(edge, 0.0, 1.0);
+
+      vec3 color = texture2D(t, v).rgb;
+      float levels = max(posterize, 1.0);
+      color = floor(color * levels) / levels;
+      float gray = dot(color, luma);
+      color = mix(vec3(gray), color, saturation);
+      float edgeFactor = clamp(edgeWeight * edge, 0.0, 1.0);
+      color = mix(color, vec3(0.0), edgeFactor);
+      gl_FragColor = vec4(color, 1.0);
+    }
   `;
   const vs = gl.createShader(gl.VERTEX_SHADER)!;
   gl.shaderSource(vs, vsrc);
@@ -39,22 +79,64 @@ export function applyShader(video: HTMLVideoElement, canvas: HTMLCanvasElement) 
   gl.attachShader(program, fs);
   gl.linkProgram(program);
   gl.useProgram(program);
+
   const buffer = gl.createBuffer();
   gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
-  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), gl.STATIC_DRAW);
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]),
+    gl.STATIC_DRAW
+  );
   const loc = gl.getAttribLocation(program, 'a');
   gl.enableVertexAttribArray(loc);
   gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+
   const tex = gl.createTexture();
   gl.bindTexture(gl.TEXTURE_2D, tex);
   gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
   gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+
+  const pixelLoc = gl.getUniformLocation(program, 'pixel');
+  gl.uniform2f(pixelLoc, 1 / video.videoWidth, 1 / video.videoHeight);
+  const edgeLoc = gl.getUniformLocation(program, 'edgeWeight');
+  const posterizeLoc = gl.getUniformLocation(program, 'posterize');
+  const saturationLoc = gl.getUniformLocation(program, 'saturation');
+
+  const state = {
+    edgeWeight: 1,
+    posterize: 8,
+    saturation: 1,
+  };
+
+  function setUniforms(values: {
+    edgeWeight?: number;
+    posterize?: number;
+    saturation?: number;
+  }) {
+    Object.assign(state, values);
+  }
+
   function render() {
     if (video.readyState >= 2) {
-      gl.texImage2D(gl.TEXTURE_2D,0,gl.RGBA,gl.RGBA,gl.UNSIGNED_BYTE,video);
-      gl.drawArrays(gl.TRIANGLE_STRIP,0,4);
+      gl.uniform1f(edgeLoc, state.edgeWeight);
+      gl.uniform1f(posterizeLoc, state.posterize);
+      gl.uniform1f(saturationLoc, state.saturation);
+      gl.texImage2D(
+        gl.TEXTURE_2D,
+        0,
+        gl.RGBA,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        video
+      );
+      gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
     }
     requestAnimationFrame(render);
   }
   render();
+
+  return { setUniforms };
 }


### PR DESCRIPTION
## Summary
- Allow WebGL shader to accept edge, posterize, and saturation uniforms
- Implement Sobel edge detection, color quantization, and saturation adjustment in fragment shader
- Expose sliders in UI to tweak shader parameters live

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bebed0c32c832e85933a02a3344be0