### PR TITLE
feat: support additional video styles with dynamic model loading

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -18,13 +18,17 @@ const saturationInput = document.getElementById('saturation') as HTMLInputElemen
 
 let shader: ShaderController | null = null;
 
-// Populate style options
-for (const p of STYLES) {
-  const opt = document.createElement('option');
-  opt.value = p.id;
-  opt.textContent = p.name;
-  styleSelect.appendChild(opt);
+function populateStyles() {
+  styleSelect.innerHTML = '';
+  for (const p of STYLES) {
+    const opt = document.createElement('option');
+    opt.value = p.id;
+    opt.textContent = p.name;
+    styleSelect.appendChild(opt);
+  }
 }
+
+populateStyles();
 
 uploadInput.addEventListener('change', () => {
   const file = uploadInput.files?.[0];


### PR DESCRIPTION
## Summary
- expand style presets with manga, watercolor, and pencil options
- load ONNX models per style and cache sessions
- keep style dropdown synced with preset list

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68bed50b2640832e8c045b05bb1bac10